### PR TITLE
Fix a broken link in the docs

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Pulumi AzAPI provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@ediri/azapi`](https://www.npmjs.com/package/@ediri/azapi)
 * Python: [`ediri_azapi`](https://pypi.org/project/ediri_azapi/)
-* Go: [`github.com/dirien/pulumi-azapi/sdk/go/azapi`](https://github.com/dirien/pulumi-azapi/sdk)
+* Go: [`github.com/dirien/pulumi-azapi/sdk/go/azapi`](https://github.com/dirien/pulumi-azapi)
 * .NET: [`ediri.Azapi`](https://www.nuget.org/packages/ediri.Azapi)
 
 ## Configuration Options


### PR DESCRIPTION
The convention for these links seems to be to point to the top level of the repo, so this change does that.